### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cafeobj (1.6.0-3) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 15:38:45 +0000
+
 cafeobj (1.6.0-2) unstable; urgency=medium
 
   * add watch file
@@ -62,7 +68,7 @@ cafeobj (1.5.5-1) unstable; urgency=medium
   * cherry pick upstream change to use tikz instead of graffle generated
     images in namespace documentation
   * adjust autoconf files to rebuild all documentation
-  * add texlive-generic-extra to build deps (Closes: #830445) 
+  * add texlive-generic-extra to build deps (Closes: #830445)
   * documentation files: use tikz instead of graffle generated pdf
   * bump standards version, no changes necessary
   * add MotoyaLMaru fonts to build deps for logo

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 cafeobj (1.6.0-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Name (from
+    ./configure), Repository, Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 15:38:45 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -12,15 +12,15 @@ Package: cafeobj
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: new generation algebraic specification and programming language
- CafeOBJ is a most advanced formal specification language which 
+ CafeOBJ is a most advanced formal specification language which
  inherits many advanced features (e.g. flexible mix-fix syntax,
  powerful and clear typing system with ordered sorts, parameteric
  modules and views for instantiating the parameters, and module
  expressions, etc.) from OBJ (or more exactly OBJ3) algebraic
  specification language.
  .
- CafeOBJ is a language for writing formal (i.e. mathematical) 
- specifications of models for wide varieties of software and systems, 
+ CafeOBJ is a language for writing formal (i.e. mathematical)
+ specifications of models for wide varieties of software and systems,
  and verifying properties of them. CafeOBJ implements equational logic
  by rewriting and can be used as a powerful interactive theorem proving
  system. Specifiers can write proof scores also in CafeOBJ and doing
@@ -30,7 +30,7 @@ Description: new generation algebraic specification and programming language
  institutions. The CafeOBJ cube shows the structure of the various
  logics underlying the combination of the various paradigms implemented
  by the language. Proof scores in CafeOBJ are also based on institution
- based rigorous semantics, and can be constructed using a complete set 
+ based rigorous semantics, and can be constructed using a complete set
  of proof rules.
 
 Package: cafeobj-mode

--- a/debian/rules
+++ b/debian/rules
@@ -102,4 +102,3 @@ binary-arch: build install
 
 
 .PHONY: config build clean binary-indep binary-arch binary install
-

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+Name: CafeOBJ
+Bug-Database: https://github.com/CafeOBJ/cafeobj/issues
+Bug-Submit: https://github.com/CafeOBJ/cafeobj/issues/new
+Repository: https://github.com/CafeOBJ/cafeobj.git
+Repository-Browse: https://github.com/CafeOBJ/cafeobj


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Name (from ./configure), Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/cafeobj/c44d82d4-f299-4f9e-b195-d9f9c30049d6.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/c44d82d4-f299-4f9e-b195-d9f9c30049d6/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c44d82d4-f299-4f9e-b195-d9f9c30049d6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c44d82d4-f299-4f9e-b195-d9f9c30049d6/diffoscope)).
