### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ cafeobj (1.6.0-3) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Name (from
     ./configure), Repository, Repository-Browse.
+  * Remove constraints unnecessary since buster (oldstable):
+    + cafeobj-mode: Drop versioned constraint on emacsen-common in Depends.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 15:38:45 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Description: new generation algebraic specification and programming language
 
 Package: cafeobj-mode
 Architecture: all
-Depends: emacsen-common (>= 2.0.8), ${misc:Depends}
+Depends: emacsen-common, ${misc:Depends}
 Recommends: cafeobj
 Description: Emacs major mode for editing CafeOBJ source code
  cafeobj-mode provides syntax highlighting and indentation for CafeOBJ


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/cafeobj/b4d5c053-e253-4cc3-a061-5da7a583432d.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*cafeobj\*\*
### Control files of package cafeobj-mode: lines which differ (wdiff format)
* Depends: emacsen-common [-(>= 2.0.8)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b4d5c053-e253-4cc3-a061-5da7a583432d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b4d5c053-e253-4cc3-a061-5da7a583432d/diffoscope)).
