### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ cafeobj (1.6.0-3) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Name (from
     ./configure), Repository, Repository-Browse.
+  * Use secure URI in Homepage field.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 15:38:45 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ cafeobj (1.6.0-3) UNRELEASED; urgency=medium
     ./configure), Repository, Repository-Browse.
   * Use secure URI in Homepage field.
   * Update standards version to 4.6.1, no changes needed.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 15:38:45 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ cafeobj (1.6.0-3) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Name (from
     ./configure), Repository, Repository-Browse.
   * Use secure URI in Homepage field.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 15:38:45 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: science
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
 Build-Depends: debhelper (>= 10), sbcl
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Homepage: https://cafeobj.org/
 Vcs-Git: https://github.com/CafeOBJ/cafeobj.git
 Vcs-Browser: https://github.com/CafeOBJ/cafeobj

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: science
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
 Build-Depends: debhelper (>= 10), sbcl
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Homepage: https://cafeobj.org/
 Vcs-Git: https://github.com/CafeOBJ/cafeobj.git
 Vcs-Browser: https://github.com/CafeOBJ/cafeobj

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
 Build-Depends: debhelper (>= 10), sbcl
 Standards-Version: 4.5.0
-Homepage: http://cafeobj.org/
+Homepage: https://cafeobj.org/
 Vcs-Git: https://github.com/CafeOBJ/cafeobj.git
 Vcs-Browser: https://github.com/CafeOBJ/cafeobj
 


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

File lists identical (after any substitutions)
### Control files of package cafeobj: lines which differ (wdiff format)
* Homepage: [-http&#8203;://cafeobj.org/-] {+https&#8203;://cafeobj.org/+}
### Control files of package cafeobj-mode: lines which differ (wdiff format)
* Homepage: [-http&#8203;://cafeobj.org/-] {+https&#8203;://cafeobj.org/+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1a88b78c-68a5-447e-898c-80f891a9d12b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1a88b78c-68a5-447e-898c-80f891a9d12b/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/1a88b78c-68a5-447e-898c-80f891a9d12b.